### PR TITLE
[CAP-6022] Improve Env Var Usage

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -19,6 +19,10 @@ if (!renderAPIKey ) {
     process.exit(1);
 }
 
+app.get('/', (req: Request, res: Response) => {
+  res.send('Render Webhook Receiver is listening!')
+})
+
 app.post("/webhook", express.raw({type: 'application/json'}), (req: Request, res: Response, next: NextFunction) => {
     try {
         validateWebhook(req);


### PR DESCRIPTION
- In the README and elsewhere in the Renderverse, we use Render API keys not tokens. Let's align our env vars
- Let's fail start up if you're missing a required env var
- Let's serve a page for GET /, so that users can see a friendly page when they visit the site with their browser